### PR TITLE
arm64: allwinner: a64: dts: disable IRQ of LIS3MDL on PinePhone

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
+++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
@@ -235,8 +235,6 @@
 	lis3mdl@1e {
 		compatible = "st,lis3mdl-magn";
 		reg = <0x1e>;
-		interrupt-parent = <&pio>;
-		interrupts = <1 1 IRQ_TYPE_LEVEL_HIGH>; /* PB1 */
 		vdd-supply = <&reg_dldo1>;
 	};
 


### PR DESCRIPTION
The interrupt line of LIS3MDL on PinePhone is wrongly connected, at
least on current revisions.

Remove the IRQ from the device tree.

This fix is already in the mainlined version of PinePhone device tree.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>