### PR TITLE
Implement validateBufferSize() method

### DIFF
--- a/gralloc.cpp
+++ b/gralloc.cpp
@@ -163,6 +163,19 @@ static int gbm_mod_lock_ycbcr(gralloc_module_t const *mod, buffer_handle_t handl
 	return err;
 }
 
+static int32_t gbm_mod_validate_buffer_size(const gralloc_module_t *mod,
+		buffer_handle_t handle, uint32_t w, uint32_t h, int32_t format, int usage, uint32_t stride)
+{
+	struct gbm_module_t *dmod = (struct gbm_module_t *) mod;
+	int err;
+
+	pthread_mutex_lock(&dmod->mutex);
+	err = gbm_validate_buffer_size(handle, w, h, format, usage, stride);
+	pthread_mutex_unlock(&dmod->mutex);
+
+	return err;
+}
+
 static int gbm_mod_close_gpu0(struct hw_device_t *dev)
 {
 	struct gbm_module_t *dmod = (struct gbm_module_t *)dev->module;
@@ -265,7 +278,8 @@ struct gbm_module_t HAL_MODULE_INFO_SYM = {
 		.lock = gbm_mod_lock,
 		.unlock = gbm_mod_unlock,
 		.lock_ycbcr = gbm_mod_lock_ycbcr,
-		.perform = gbm_mod_perform
+		.perform = gbm_mod_perform,
+		.validateBufferSize = gbm_mod_validate_buffer_size
 	},
 
 	.mutex = PTHREAD_MUTEX_INITIALIZER,

--- a/gralloc_gbm.cpp
+++ b/gralloc_gbm.cpp
@@ -545,6 +545,51 @@ int gralloc_gbm_bo_lock_ycbcr(buffer_handle_t handle,
 }
 
 /*
+ * Validate that the buffer can be safely accessed by a caller who assumes
+ * the specified width, height, format, usage, and stride.
+ */
+int32_t gbm_validate_buffer_size(buffer_handle_t handle, uint32_t w, uint32_t h, int32_t format,
+		int usage, uint32_t stride)
+{
+	struct gralloc_handle_t *gbm_handle = gralloc_handle(handle);
+
+	if (!gbm_handle) {
+		ALOGE("buffer validation unsuccess, bad handle: %p", gbm_handle);
+		return -EINVAL;
+	}
+
+	if (w != gbm_handle->width) {
+		ALOGE("buffer validation unsuccess, specified width %d requires %d", w, gbm_handle->width);
+		return -ENOMEM;
+	}
+
+	if (h != gbm_handle->height) {
+		ALOGE("buffer validation unsuccess, specified height %d requires %d", h, gbm_handle->height);
+		return -ENOMEM;
+	}
+
+	if (format != gbm_handle->format) {
+		ALOGE("buffer validation unsuccess, specified format 0x%x requires 0x%x", format,
+				gbm_handle->format);
+		return -ENOMEM;
+	}
+
+	if (usage != gbm_handle->usage) {
+		ALOGE("buffer validation unsuccess, specified usage 0x%x requires 0x%x", usage,
+				gbm_handle->usage);
+		return -ENOMEM;
+	}
+
+	if (stride * gralloc_gbm_get_bpp(format) != gbm_handle->stride) {
+		ALOGE("buffer validation unsuccess, specified stride %d requires %d",
+				stride * gralloc_gbm_get_bpp(format), gbm_handle->stride);
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+/*
  * Check if target device has KMS.
  */
 bool is_kms_dev(int fd)

--- a/gralloc_gbm_priv.h
+++ b/gralloc_gbm_priv.h
@@ -48,6 +48,9 @@ int gralloc_gbm_bo_unlock(buffer_handle_t handle);
 int gralloc_gbm_bo_lock_ycbcr(buffer_handle_t handle, int usage,
 		int x, int y, int w, int h, struct android_ycbcr *ycbcr);
 
+int32_t gbm_validate_buffer_size(buffer_handle_t handle, uint32_t w, uint32_t h, int32_t format,
+		int usage, uint32_t stride);
+
 struct gbm_device *gbm_dev_create(void);
 void gbm_dev_destroy(struct gbm_device *gbm);
 


### PR DESCRIPTION
The method implementation is required for passing the ValidateBufferSizeBadValue of GraphicsMapperHidlTest. The minimal implementation ensures that the input parameters from the mapper and the data accessed by the buffer handle are equal.

After merging to our fork I'm going to create the upstream PR into [gbm_gralloc](https://github.com/robherring/gbm_gralloc).

Corresponding to the [Glodroid issue#85](https://github.com/GloDroid/glodroid_manifest/issues/85).